### PR TITLE
Test for new dependenc to make installator work

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/btwael/mammouth.git"
+	},
+	"dependencies": {
+		"commander": "2.1.*"
 	}
 }


### PR DESCRIPTION
After installing mammouth by `npm install -g mammouth` I couldn't run it

```
D:\_work\XXX [master +4 ~1 -5 !]> mammouth --compile --output ./ ./src

module.js:340
    throw err;
          ^
Error: Cannot find module 'commander'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (C:\Users\Cezary\AppData\Roaming\npm\node_modules\mammouth\bin\mammouth:2:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```

This is fixing the problem.
